### PR TITLE
docs: Fix a few typos

### DIFF
--- a/TODO.rst
+++ b/TODO.rst
@@ -66,7 +66,7 @@ security integration.
 [ ] Use ``BatchedItems`` as base for ``Table``.
 
 [ ] Rename ``cone.app.browser.batch.Batch`` to
-``cone.app.browser.batch.Pagination`` provoding B/C.
+``cone.app.browser.batch.Pagination`` providing B/C.
 
 [ ] Provide a ``form_action`` property on ``cone.app.browser.form.Form``
 considering ``action_resource`` attribute. Consolidate with

--- a/docs/source/model.rst
+++ b/docs/source/model.rst
@@ -147,7 +147,7 @@ AppRoot
 ``cone.app.model.AppRoot`` derives from :ref:`FactoryNode <model_factory_node>`
 and represents the application model root node.
 
-This node gets instanciated only once on application startup. Every plugin
+This node gets instantiated only once on application startup. Every plugin
 entry point registered with :ref:`register_entry <plugins_application_model>`
 gets written to the ``factories`` attribute of the root node.
 
@@ -432,7 +432,7 @@ used:
   `Ionicons <http://ionicons.com>`_ are shipped and delivered with ``cone.app`` by
   default.
 
-``NodeInfo`` objects are not instanciated directly, instead the
+``NodeInfo`` objects are not instantiated directly, instead the
 ``cone.app.model.node_info`` decorator is used to register node types.
 
 .. code-block:: python

--- a/docs/source/security.rst
+++ b/docs/source/security.rst
@@ -24,7 +24,7 @@ For retrieval of users, groups and the assigned roles, ``node.ext.ugm`` is
 used. See :ref:`User and Group Management <user_and_group_management>` for
 details.
 
-By default, unauthenticed access to all application model nodes is prohibited.
+By default, unauthenticated access to all application model nodes is prohibited.
 
 
 Permissions
@@ -70,7 +70,7 @@ The roles which come out of the box with ``cone.app`` are:
   to this role are ``view``.
 
 - **viewer**: This role is supposed to grant users permissions needed to
-  view addidional information the default ``authenticated`` role forbids. By
+  view additional information the default ``authenticated`` role forbids. By
   default, permissions assigned to this role are ``authenticated`` role
   permissions and ``list``.
 

--- a/docs/source/translations.rst
+++ b/docs/source/translations.rst
@@ -100,7 +100,7 @@ Python
 ~~~~~~
 
 Defining translation strings in python. A translation string factory must be
-instanciated with the correct i18n domain which is used for creating
+instantiated with the correct i18n domain which is used for creating
 translation strings.
 
 .. code-block:: python

--- a/src/cone/app/browser/static/jquery-1.9.1.js
+++ b/src/cone/app/browser/static/jquery-1.9.1.js
@@ -4854,7 +4854,7 @@ Expr = Sizzle.selectors = {
 		// The identifier C does not have to be a valid language name."
 		// http://www.w3.org/TR/selectors/#lang-pseudo
 		"lang": markFunction( function( lang ) {
-			// lang value must be a valid identifider
+			// lang value must be a valid identifier
 			if ( !ridentifier.test(lang || "") ) {
 				Sizzle.error( "unsupported lang: " + lang );
 			}

--- a/src/cone/app/interfaces.py
+++ b/src/cone/app/interfaces.py
@@ -40,7 +40,7 @@ class IAdapterNode(IApplicationNode):
 
     XXX: - currently designed to adapt nodes, more generic
          - no attrs on this interface
-         - self.context insetad of self.model
+         - self.context instead of self.model
     """
     attrs = Attribute(u'Return self.model.attrs')
 

--- a/src/cone/app/workflow.py
+++ b/src/cone/app/workflow.py
@@ -101,7 +101,7 @@ class WorkflowState(Behavior):
 
 
 class WorkflowACL(Behavior):
-    """Behavior providing ACL's by worfklow state.
+    """Behavior providing ACL's by workflow state.
 
     Requires ``WorkflowState`` behavior.
     """


### PR DESCRIPTION
There are small typos in:
- TODO.rst
- docs/source/model.rst
- docs/source/security.rst
- docs/source/translations.rst
- src/cone/app/browser/static/jquery-1.9.1.js
- src/cone/app/interfaces.py
- src/cone/app/workflow.py

Fixes:
- Should read `instantiated` rather than `instanciated`.
- Should read `workflow` rather than `worfklow`.
- Should read `unauthenticated` rather than `unauthenticed`.
- Should read `providing` rather than `provoding`.
- Should read `instead` rather than `insetad`.
- Should read `identifier` rather than `identifider`.
- Should read `additional` rather than `addidional`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md